### PR TITLE
Add ACME challenge coverage and post-deploy checks

### DIFF
--- a/src/acme.js
+++ b/src/acme.js
@@ -17,7 +17,7 @@
   */
 export async function acmeChallenge(request, context) {
   const { pathname } = new URL(request.url);
-  const token = pathname.slice('.well-known/acme-challenge/'.length);
+  const token = pathname.replace(/^\/?\.well-known\/acme-challenge\//, '');
   const thumbprint = await context.env.LETSENCRYPT_ACCOUNT_THUMBPRINT;
   return new Response(`${token}.${thumbprint}`, { headers: { 'Content-Type': 'text/plain' } });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ export async function makeContext(ectx, req, env) {
  */
 export async function main(request, context = {}) {
   const { pathname } = new URL(request.url);
-  if (request.method === 'GET' && pathname && pathname.startsWith('.well-known/acme-challenge/')) {
+  if (request.method === 'GET' && pathname && pathname.startsWith('/.well-known/acme-challenge/')) {
     return acmeChallenge(request, context);
   }
   const env = context.env || {};

--- a/test/acme.test.js
+++ b/test/acme.test.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import assert from 'node:assert';
+import { acmeChallenge } from '../src/acme.js';
+
+describe('acme tests', () => {
+  it('returns response with token and thumbprint', async () => {
+    const token = 'sample-token';
+    const request = new Request(`https://example.com/.well-known/acme-challenge/${token}`);
+    const context = {
+      env: {
+        LETSENCRYPT_ACCOUNT_THUMBPRINT: 'thumbprint-value',
+      },
+    };
+
+    const response = await acmeChallenge(request, context);
+    const body = await response.text();
+    const [tokenPart, thumbprint] = body.split('.');
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get('content-type'), 'text/plain');
+    assert.strictEqual(tokenPart, token);
+    assert.ok(thumbprint); // ensure thumbprint not empty
+  });
+
+  it('awaits thumbprint value from env bindings', async () => {
+    const token = 'await-token';
+    const request = new Request(`https://example.com/.well-known/acme-challenge/${token}`);
+    const thumbprintPromise = Promise.resolve('resolved-thumbprint');
+    const context = {
+      env: {
+        LETSENCRYPT_ACCOUNT_THUMBPRINT: thumbprintPromise,
+      },
+    };
+
+    const response = await acmeChallenge(request, context);
+    const body = await response.text();
+
+    assert.strictEqual(body, `${token}.resolved-thumbprint`);
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,7 +11,7 @@
  */
 
 import assert from 'node:assert';
-import { makeContext } from '../src/index.js';
+import { main, makeContext } from '../src/index.js';
 
 describe('index tests', () => {
   describe('makeContext', () => {
@@ -92,6 +92,25 @@ describe('index tests', () => {
 
       assert.strictEqual(ctx.url.host, 'app.aem-mesh.live');
       assert.strictEqual(ctx.info.subdomain, 'app');
+    });
+  });
+
+  describe('main', () => {
+    it('handles ACME challenge requests directly', async () => {
+      const token = 'test-token';
+      const request = new Request(`https://example.com/.well-known/acme-challenge/${token}`);
+      const context = {
+        env: {
+          LETSENCRYPT_ACCOUNT_THUMBPRINT: 'thumbprint',
+        },
+      };
+
+      const response = await main(request, context);
+      const body = await response.text();
+
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.headers.get('content-type'), 'text/plain');
+      assert.strictEqual(body, `${token}.thumbprint`);
     });
   });
 });

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -88,6 +88,19 @@ providers
         assert.strictEqual(res.status, 200, await res.text());
       }).timeout(4000);
 
+      it('returns ACME challenge response with token and thumbprint', async () => {
+        const challengeToken = 'post-deploy-token';
+        const { url, ...opts } = getFetchOptions(`/.well-known/acme-challenge/${challengeToken}`, 'main', 'helix-website', 'adobe');
+        const res = await fetch(url, opts);
+        const body = await res.text();
+
+        assert.strictEqual(res.status, 200, body);
+        assert.strictEqual(res.headers.get('content-type'), 'text/plain');
+        assert.ok(body.startsWith(`${challengeToken}.`), `Expected body to start with "${challengeToken}." but got "${body}"`);
+        const thumbprint = body.slice(challengeToken.length + 1);
+        assert.ok(thumbprint.length > 0, 'Expected thumbprint to be present in ACME challenge response');
+      }).timeout(4000);
+
       Object.entries(prodPaths).forEach(([path, result]) => {
         it(`returns ${result.status} for ${path}`, async () => {
           const { url, ...opts } = getFetchOptions(path, 'main', name, 'aemsites');


### PR DESCRIPTION
## Summary
- add focused unit coverage for the ACME challenge helper
- fix ACME routing in the main entrypoint and cover it with an integration test
- extend the post-deploy checks to validate the ACME challenge response

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917da56dec48333badcb131d0cd5a68)