### PR TITLE
feat: inline fragments based on path prefix or #inline suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ wrangler-versioned.toml
 *.pem
 bin/main.wasm
 pkg/helix-mixer.tar.gz
+.claude/settings.local.json

--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { decompressResponse } from './decompress.js';
 import { errorWithResponse, ffetch, globToRegExp } from './util.js';
 
 /** @type {'CONFIG_SERVICE' | 'STORAGE'} */
@@ -88,7 +89,10 @@ export async function resolveConfig(ctx, overrides = {}) {
         throw errorWithResponse(res.status, 'config fetch failed');
       }
     } else {
-      const json = await res.json();
+      // Decompress before parsing — Fastly Compute doesn't auto-decompress fetch responses,
+      // so res.json() fails on gzip-encoded bodies from the config CDN.
+      const decompressed = await decompressResponse(res, { log });
+      const json = await decompressed.json();
       rawConfig = json.public?.mixerConfig ?? { patterns: {}, backends: {} };
     }
   }

--- a/src/config.js
+++ b/src/config.js
@@ -107,12 +107,16 @@ export async function resolveConfig(ctx, overrides = {}) {
       throw new Error('invalid config object');
     }
 
-    const { patterns, backends } = rawConfig;
+    const { patterns, backends, inlineFragments } = rawConfig;
     if (!patterns || Object.values(patterns).some((p) => typeof p !== 'string')) {
       throw new Error('invalid pattern, expected type string');
     }
     if (!backends || Object.values(backends).some((b) => typeof b.origin !== 'string')) {
       throw new Error('invalid backend, expected type string');
+    }
+    if (inlineFragments && inlineFragments.paths !== undefined
+      && (!Array.isArray(inlineFragments.paths) || inlineFragments.paths.some((path) => typeof path !== 'string'))) {
+      throw new Error('invalid inlineFragments config, expected paths array of strings');
     }
   } catch (e) {
     throw errorWithResponse(400, e.message);

--- a/src/decompress.js
+++ b/src/decompress.js
@@ -69,14 +69,39 @@ export async function decompressResponse(response, ctx) {
 }
 
 /**
- * Attempts to read text from a potentially compressed response.
- * Automatically decompresses if needed.
+ * Read text from a potentially compressed response. Reads the body as an
+ * ArrayBuffer and inspects magic bytes to decide whether decompression is
+ * actually needed — some runtimes (Cloudflare Workers) transparently
+ * decompress the body but leave the content-encoding header, causing
+ * DecompressionStream to fail on already-plain bytes.
  *
  * @param {Response} response - The potentially compressed response
  * @param {object} ctx - Context object with logging
  * @returns {Promise<string>} - The decompressed text content
  */
 export async function readResponseText(response, ctx) {
-  const decompressed = await decompressResponse(response, ctx);
-  return decompressed.text();
+  const contentEncoding = response.headers.get('content-encoding');
+  if (!contentEncoding || contentEncoding === 'identity') {
+    return response.text();
+  }
+
+  const buf = await response.arrayBuffer();
+  const bytes = new Uint8Array(buf);
+
+  const isGzip = contentEncoding === 'gzip'
+    && bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b;
+  const isDeflate = contentEncoding === 'deflate'
+    && bytes.length >= 1 && bytes[0] === 0x78;
+
+  if (isGzip || isDeflate) {
+    const format = isGzip ? 'gzip' : 'deflate';
+    ctx.log.debug(`Decompressing ${format} response body`);
+    const stream = new Response(bytes).body.pipeThrough(
+      new DecompressionStream(format),
+    );
+    return new Response(stream).text();
+  }
+
+  ctx.log.debug('Response body already decompressed despite content-encoding header');
+  return new TextDecoder().decode(bytes);
 }

--- a/src/inlines.js
+++ b/src/inlines.js
@@ -499,16 +499,13 @@ export default async function inlineResources(ctx, beurl, response) {
     return response;
   }
 
-  // get the markup - automatically handles decompression if needed.
-  // Clone first so we can fall back to .text() when the runtime already
-  // decompressed the body but left the content-encoding header (Cloudflare Workers).
+  // get the markup - automatically handles decompression if needed
   let markup;
-  const responseClone = response.clone();
   try {
     markup = await readResponseText(response, ctx);
-  } catch {
-    ctx.log.warn('Decompression failed, reading response text directly');
-    markup = await responseClone.text();
+  } catch (error) {
+    ctx.log.error('Failed to read response text:', error);
+    throw error;
   }
   const meta = extractInlineMeta(markup);
   const navPath = ctx.config.inlineNav ? meta.nav : undefined;

--- a/src/inlines.js
+++ b/src/inlines.js
@@ -22,6 +22,21 @@ const INLINE_ORIGINS = [
   'pipeline-cloudflare.adobecommerce.live',
 ];
 
+const ANCHOR_RE = /<a(?=[\s>])(?:[^>"']|"[^"]*"|'[^']*')*>[\s\S]*?<\/a>/gi;
+/**
+ * Max chars after `</a>` to look for a matching `</p>` / `</div>`
+ * (avoids scanning the rest of the document).
+ */
+const WRAPPER_CLOSE_LOOKAHEAD = 1024;
+const CLOSE_WRAPPER_RE = /^\s*<\/(?<tag>p|div)>/i;
+/**
+ * Open tag interior between `<` and `>` for `<p` / `<div`
+ * (same constraint as former OPEN_WRAPPER_RE).
+ */
+const OPEN_WRAPPER_INNER_RE = /^(?<tag>p|div)(?:\s[^>]*)?$/i;
+const OPEN_TAG_RE = /^<a(?=[\s>])(?:[^>"']|"[^"]*"|'[^']*')*>/i;
+const HREF_ATTR_RE = /\shref\s*=\s*(["'])(?<href>\/[^"'<>]*)\1/i;
+
 /**
  * Pull out the nav/footer location from the meta tags, if present.
  * Exclude resources if they dont also exist in the body.
@@ -62,6 +77,253 @@ function indent(markup, indentCount) {
 }
 
 /**
+ * Preserve the first line as-is because the line's leading whitespace remains
+ * outside the replacement range in the source markup.
+ * @param {string} markup
+ * @param {number} indentCount
+ * @returns {string}
+ */
+function indentSubsequentLines(markup, indentCount) {
+  return markup.replace(/\n/g, `\n${' '.repeat(indentCount)}`);
+}
+
+/**
+ * Header bag compatible with DOM and worker `Headers` (only `.get` is used).
+ * @param {{ get: (name: string) => string | null | undefined }} headers
+ * @returns {Record<string, Set<string>>}
+ */
+function createCacheKeys(headers) {
+  return {
+    // fastly
+    'surrogate-key': new Set(headers.get('surrogate-key')?.split(' ') || []),
+    // akamai
+    'edge-cache-tag': new Set(headers.get('edge-cache-tag')?.split(',') || []),
+    // cloudflare
+    'cache-tag': new Set(headers.get('cache-tag')?.split(',') || []),
+    // cache-tag headers may be stripped by cloudflare, collect x-cache-tag as well
+    'x-cache-tag': new Set(headers.get('x-cache-tag')?.split(',') || []),
+  };
+}
+
+/**
+ * @param {Record<string, Set<string>>} cacheKeys
+ * @param {{ get: (name: string) => string | null | undefined }} headers
+ */
+function mergeCacheKeys(cacheKeys, headers) {
+  for (const [key, value] of Object.entries(cacheKeys)) {
+    const delimiter = key === 'surrogate-key' ? ' ' : ',';
+    const strValue = headers.get(key)?.trim();
+    if (strValue) {
+      strValue.split(delimiter).forEach((v) => value.add(v.trim()));
+    }
+  }
+}
+
+/**
+ * @param {Context} ctx
+ * @returns {string[]}
+ */
+function getInlinePaths(ctx) {
+  return ctx.config.inlineFragments?.paths || [];
+}
+
+/**
+ * @param {string} markup
+ * @param {number} index
+ * @returns {number}
+ */
+function getIndentCount(markup, index) {
+  const lineStart = markup.lastIndexOf('\n', index - 1) + 1;
+  let indentCount = 0;
+  for (let i = lineStart; i < index; i += 1) {
+    const ch = markup[i];
+    if (ch === ' ') {
+      indentCount += 1;
+    } else if (ch === '\t') {
+      indentCount += 2;
+    } else {
+      return 0;
+    }
+  }
+  return indentCount;
+}
+
+/**
+ * @param {Context} ctx
+ * @param {string} path
+ * @returns {URL}
+ */
+function getInlineUrl(ctx, path) {
+  const url = new URL(path, `${ctx.config.protocol}://${ctx.config.origin}`);
+  url.hash = '';
+  if (!url.pathname.endsWith('.plain.html')) {
+    url.pathname = `${url.pathname}.plain.html`;
+  }
+  return url;
+}
+
+/**
+ * Returns the normalized href ending with #inline if it should be inlined, or null.
+ * Path-matched hrefs get #inline appended; hrefs already ending with #inline pass through.
+ * @param {string} href
+ * @param {string[]} inlinePaths
+ * @returns {string|null}
+ */
+function normalizeInlineHref(href, inlinePaths) {
+  if (!href || !href.startsWith('/') || href.startsWith('//')) {
+    return null;
+  }
+  if (href.endsWith('#inline')) {
+    return href;
+  }
+  if (inlinePaths.length) {
+    const qIdx = href.indexOf('?');
+    const hIdx = href.indexOf('#');
+    const endIdx = Math.min(
+      qIdx >= 0 ? qIdx : href.length,
+      hIdx >= 0 ? hIdx : href.length,
+    );
+    const pathname = href.slice(0, endIdx);
+    if (inlinePaths.some((path) => pathname.startsWith(path))) {
+      const withoutHash = hIdx >= 0 ? href.slice(0, hIdx) : href;
+      return `${withoutHash}#inline`;
+    }
+  }
+  return null;
+}
+
+/**
+ * @param {string} anchorMarkup
+ * @returns {string}
+ */
+function extractHref(anchorMarkup) {
+  const openTag = anchorMarkup.match(OPEN_TAG_RE)?.[0];
+  if (!openTag) {
+    return '';
+  }
+
+  return openTag.match(HREF_ATTR_RE)?.groups?.href || '';
+}
+
+/**
+ * @param {string} markup
+ * @param {RegExp} re
+ * @returns {{ index: number, text: string, groups: Record<string, string> }[]}
+ */
+function collectMatches(markup, re) {
+  const matches = [];
+  re.lastIndex = 0;
+  let match = re.exec(markup);
+  while (match) {
+    matches.push({
+      index: match.index,
+      text: match[0],
+      groups: match.groups || {},
+    });
+    match = re.exec(markup);
+  }
+  return matches;
+}
+
+/**
+ * @param {{ start: number, end: number }[]} replacements
+ * @param {number} index
+ * @returns {boolean}
+ */
+function replacementExistsAt(replacements, index) {
+  return replacements.some(({ start, end }) => index >= start && index < end);
+}
+
+/**
+ * If the anchor at [start, end) is directly inside a minimal `<p>` or `<div>` wrapper
+ * (only whitespace between the open `>` and `<a`, and optional whitespace then `</p|div>`
+ * after `</a>`), return that wrapper's span in markup. Uses index scans instead of slicing
+ * the entire prefix.
+ *
+ * @param {string} markup
+ * @param {number} start - index of `<a`
+ * @param {number} end - index after `</a>`
+ * @returns {{ start: number, end: number } | null}
+ */
+function findImmediateWrapper(markup, start, end) {
+  let i = start - 1;
+  while (i >= 0 && /\s/.test(markup[i])) {
+    i -= 1;
+  }
+  if (i < 0 || markup[i] !== '>') {
+    return null;
+  }
+  const gt = i;
+  let lt = gt - 1;
+  while (lt >= 0 && markup[lt] !== '<') {
+    lt -= 1;
+  }
+  if (lt < 0) {
+    return null;
+  }
+  const inner = markup.slice(lt + 1, gt);
+  const openMatch = inner.match(OPEN_WRAPPER_INNER_RE);
+  if (!openMatch?.groups?.tag) {
+    return null;
+  }
+  const openTag = openMatch.groups.tag.toLowerCase();
+
+  const afterLimit = Math.min(markup.length, end + WRAPPER_CLOSE_LOOKAHEAD);
+  const closeRegion = markup.slice(end, afterLimit);
+  const closeMatch = closeRegion.match(CLOSE_WRAPPER_RE);
+  if (!closeMatch?.groups?.tag) {
+    return null;
+  }
+  if (closeMatch.groups.tag.toLowerCase() !== openTag) {
+    return null;
+  }
+
+  return {
+    start: lt,
+    end: end + closeMatch[0].length,
+  };
+}
+
+/**
+ * @param {string} markup
+ * @param {{ start: number, end: number, replacement: string }[]} replacements
+ * @returns {string}
+ */
+function applyReplacements(markup, replacements) {
+  return replacements
+    .sort((a, b) => b.start - a.start)
+    .reduce((acc, { start, end, replacement }) => `${acc.slice(0, start)}${replacement}${acc.slice(end)}`, markup);
+}
+
+/**
+ * @param {Context} ctx
+ * @param {Record<string, Set<string>>} cacheKeys
+ * @param {string} path
+ * @returns {Promise<string|null>}
+ */
+async function fetchFragmentMarkup(ctx, cacheKeys, path) {
+  const url = getInlineUrl(ctx, path);
+  const tagResponse = await ffetch(url.toString(), {
+    headers: {
+      'accept-encoding': 'identity',
+      'x-byo-cdn-type': ctx.info.headers['x-byo-cdn-type'],
+      'x-push-invalidation': ctx.info.headers['x-push-invalidation'],
+    },
+    cf: {
+      cacheEverything: false,
+      cacheTtl: 0,
+    },
+  });
+  if (tagResponse.status !== 200 || !tagResponse.headers.get('content-type')?.includes('text/html')) {
+    ctx.log.warn(`Failed to inline fragment from ${path}: ${tagResponse.status}`);
+    return null;
+  }
+
+  mergeCacheKeys(cacheKeys, tagResponse.headers);
+  return tagResponse.text();
+}
+
+/**
  * Inline a tag into the markup and return the updated markup.
  * Append any new cache keys to the cacheKeys array.
  * @param {Context} ctx
@@ -93,14 +355,7 @@ async function inlineTag(ctx, markup, cacheKeys, path, tag) {
     return markup;
   }
 
-  // merge cachekeys
-  for (const [key, value] of Object.entries(cacheKeys)) {
-    const delimiter = key === 'surrogate-key' ? ' ' : ',';
-    const strValue = tagResponse.headers.get(key)?.trim();
-    if (strValue) {
-      strValue.split(delimiter).forEach((v) => value.add(v.trim()));
-    }
-  }
+  mergeCacheKeys(cacheKeys, tagResponse.headers);
   const tagMarkup = await tagResponse.text();
   const indentMatch = markup.match(new RegExp(`([^\\S\\n]*)<${tag}>`));
   /* c8 ignore next */
@@ -110,6 +365,71 @@ async function inlineTag(ctx, markup, cacheKeys, path, tag) {
 ${indent(tagMarkup.trim(), indentCount + 2)}
 ${' '.repeat(indentCount)}</${tag}>`);
   return markup;
+}
+
+/**
+ * @param {Context} ctx
+ * @param {string} markup
+ * @param {Record<string, Set<string>>} cacheKeys
+ * @returns {Promise<string>}
+ */
+async function inlineFragments(ctx, markup, cacheKeys) {
+  const inlinePaths = getInlinePaths(ctx);
+  if (inlinePaths.length === 0 && !markup.includes('#inline')) {
+    return markup;
+  }
+
+  const anchorMatches = collectMatches(markup, ANCHOR_RE)
+    .map((match) => {
+      const href = normalizeInlineHref(extractHref(match.text), inlinePaths);
+      return href ? { ...match, href } : null;
+    })
+    .filter(Boolean);
+
+  if (!anchorMatches.length) return markup;
+
+  // Fetch unique fragments only, all in parallel
+  const uniqueHrefs = [...new Set(anchorMatches.map((m) => m.href))];
+  /** @type {Map<string, string>} */
+  const fragmentMap = new Map();
+  await Promise.all(uniqueHrefs.map(async (href) => {
+    const fm = await fetchFragmentMarkup(ctx, cacheKeys, href);
+    if (fm) {
+      fragmentMap.set(href, fm);
+    }
+  }));
+
+  if (!fragmentMap.size) return markup;
+
+  const replacements = anchorMatches
+    .map((match) => {
+      const fragmentMarkup = fragmentMap.get(match.href);
+      if (!fragmentMarkup) return null;
+
+      const wrapper = findImmediateWrapper(markup, match.index, match.index + match.text.length);
+      if (wrapper) {
+        return {
+          start: wrapper.start,
+          end: wrapper.end,
+          replacement: indentSubsequentLines(
+            fragmentMarkup.trim(),
+            getIndentCount(markup, wrapper.start),
+          ),
+        };
+      }
+      return {
+        start: match.index,
+        end: match.index + match.text.length,
+        replacement: fragmentMarkup.trim(),
+      };
+    })
+    .filter(Boolean);
+
+  const dedupedReplacements = replacements.filter((replacement, index) => !replacementExistsAt(
+    replacements.slice(0, index),
+    replacement.start,
+  ));
+  return dedupedReplacements.length ? applyReplacements(markup, dedupedReplacements) : markup;
 }
 
 /**
@@ -135,7 +455,7 @@ function getCompressionHint(ctx) {
  */
 export function inlineConfigured(ctx) {
   const { config } = ctx;
-  return !!config.inlineNav || !!config.inlineFooter;
+  return !!config.inlineNav || !!config.inlineFooter || !!config.inlineFragments;
 }
 
 /**
@@ -148,6 +468,9 @@ export function inlineConfigured(ctx) {
  *   5. is not a .plain.html resource
  * Then fetch and inline the nav and/or footer markup into the response body
  * and include the corresponding cache keys.
+ *
+ * Additionally, if `inlineFragments` is configured, inline fragment links
+ * (by path prefix or #inline suffix) into the markup.
  *
  * @param {Context} ctx
  * @param {URL} beurl
@@ -176,18 +499,30 @@ export default async function inlineResources(ctx, beurl, response) {
     return response;
   }
 
-  // get the markup - automatically handles decompression if needed
+  // get the markup - automatically handles decompression if needed.
+  // Clone first so we can fall back to .text() when the runtime already
+  // decompressed the body but left the content-encoding header (Cloudflare Workers).
   let markup;
+  const responseClone = response.clone();
   try {
     markup = await readResponseText(response, ctx);
-  } catch (error) {
-    ctx.log.error('Failed to read response text:', error);
-    throw error;
+  } catch {
+    ctx.log.warn('Decompression failed, reading response text directly');
+    markup = await responseClone.text();
   }
   const meta = extractInlineMeta(markup);
-  if (!meta.nav && !meta.footer) {
+  const navPath = ctx.config.inlineNav ? meta.nav : undefined;
+  const footerPath = ctx.config.inlineFooter ? meta.footer : undefined;
+
+  // --- Inline fragments (additive, only when inlineFragments is configured) ---
+  let fragmentCacheKeys;
+  if (ctx.config.inlineFragments) {
+    fragmentCacheKeys = createCacheKeys(response.headers);
+    markup = await inlineFragments(ctx, markup, fragmentCacheKeys);
+  }
+
+  if (!navPath && !footerPath) {
     const compressionHint = getCompressionHint(ctx);
-    // Remove content-encoding since we decompressed the response
     const headers = new Headers(response.headers);
     headers.delete('content-encoding');
     headers.delete('content-length');
@@ -195,25 +530,39 @@ export default async function inlineResources(ctx, beurl, response) {
       headers.set('x-compress-hint', compressionHint);
     }
 
-    // Return uncompressed markup - CDN will handle compression via x-compress-hint
+    if (fragmentCacheKeys) {
+      const cfUnion = new Set([
+        ...fragmentCacheKeys['cache-tag'],
+        ...fragmentCacheKeys['x-cache-tag'],
+      ]);
+      fragmentCacheKeys['cache-tag'] = cfUnion;
+      fragmentCacheKeys['x-cache-tag'] = cfUnion;
+
+      Object.entries(fragmentCacheKeys).forEach(([key, value]) => {
+        const strValue = [...value].join(key === 'surrogate-key' ? ' ' : ',').trim();
+        if (strValue) {
+          headers.set(key, strValue);
+        }
+      });
+    }
+
     return new Response(markup, {
       status: response.status,
       headers,
     });
   }
 
-  const cacheKeys = {
-    // fastly
-    'surrogate-key': new Set(response.headers.get('surrogate-key')?.split(' ') || []),
-    // akamai
-    'edge-cache-tag': new Set(response.headers.get('edge-cache-tag')?.split(',') || []),
-    // cloudflare
-    'cache-tag': new Set(response.headers.get('cache-tag')?.split(',') || []),
-    // cache-tag headers may be stripped by cloudflare, collect x-cache-tag as well
-    'x-cache-tag': new Set(response.headers.get('x-cache-tag')?.split(',') || []),
-  };
-  markup = await inlineTag(ctx, markup, cacheKeys, meta.nav, 'header');
-  markup = await inlineTag(ctx, markup, cacheKeys, meta.footer, 'footer');
+  const cacheKeys = createCacheKeys(response.headers);
+
+  // Merge in any fragment cache keys
+  if (fragmentCacheKeys) {
+    for (const [key, value] of Object.entries(fragmentCacheKeys)) {
+      value.forEach((v) => cacheKeys[key].add(v));
+    }
+  }
+
+  markup = await inlineTag(ctx, markup, cacheKeys, navPath, 'header');
+  markup = await inlineTag(ctx, markup, cacheKeys, footerPath, 'footer');
 
   // rebuild the response with the updated markup and cache keys
   // Combine cloudflare cache tags across both headers so both contain the union

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -16,6 +16,9 @@ declare global {
     // inlines
     inlineNav?: boolean;
     inlineFooter?: boolean;
+    inlineFragments?: {
+      paths?: string[];
+    };
   }
 
   /**

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -471,6 +471,36 @@ describe('Configuration Pattern Tests with Code Execution', () => {
       delete mockConfigs['invalid--config--org'];
     });
 
+    it('should handle invalid inline config structure', async () => {
+      mockConfigs['inline-invalid--config--org'] = {
+        public: {
+          mixerConfig: {
+            patterns: { '/test': 'backend1' },
+            backends: {
+              backend1: { origin: 'example.com' },
+            },
+            inlineFragments: {
+              paths: ['/fragments/', 123],
+            },
+          },
+        },
+      };
+
+      setupMockFetch();
+
+      const ctx = createMockContext('inline-invalid--config--org', '/test');
+
+      try {
+        await resolveConfig(ctx);
+        assert.fail('Should have thrown error');
+      } catch (error) {
+        assert.strictEqual(error.response.status, 400);
+        assert.ok(error.message.includes('invalid inlineFragments config'));
+      }
+
+      delete mockConfigs['inline-invalid--config--org'];
+    });
+
     it('should handle backends with missing origin', async () => {
       // Add a separate invalid config
       mockConfigs['noorigin--config--org'] = {
@@ -528,6 +558,58 @@ describe('Configuration Pattern Tests with Code Execution', () => {
       assert.strictEqual(config.ref, 'feature');
       assert.strictEqual(config.site, 'devsite');
       assert.strictEqual(config.org, 'devorg');
+    });
+  });
+
+  describe('Inline Configuration', () => {
+    it('should preserve inline paths from mixerConfig', async () => {
+      mockConfigs['inline--config--org'] = {
+        public: {
+          mixerConfig: {
+            patterns: { '/test': 'backend1' },
+            backends: {
+              backend1: { origin: 'example.com' },
+            },
+            inlineFragments: {
+              paths: ['/fragments/', '/blocks/'],
+            },
+          },
+        },
+      };
+
+      setupMockFetch();
+
+      const ctx = createMockContext('inline--config--org', '/test');
+      const config = await resolveConfig(ctx);
+
+      assert.deepStrictEqual(config.inlineFragments, {
+        paths: ['/fragments/', '/blocks/'],
+      });
+
+      delete mockConfigs['inline--config--org'];
+    });
+
+    it('should accept inlineFragments with no paths property', async () => {
+      mockConfigs['inline-nopaths--config--org'] = {
+        public: {
+          mixerConfig: {
+            patterns: { '/test': 'backend1' },
+            backends: {
+              backend1: { origin: 'example.com' },
+            },
+            inlineFragments: {},
+          },
+        },
+      };
+
+      setupMockFetch();
+
+      const ctx = createMockContext('inline-nopaths--config--org', '/test');
+      const config = await resolveConfig(ctx);
+
+      assert.deepStrictEqual(config.inlineFragments, {});
+
+      delete mockConfigs['inline-nopaths--config--org'];
     });
   });
 

--- a/test/inlines.test.js
+++ b/test/inlines.test.js
@@ -117,6 +117,430 @@ describe('inlines tests', () => {
     assert.strictEqual(body, initialBody); // unchanged
   });
 
+  it('should inline fragment markers by replacing a simple wrapper', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    mockResponses['https://main--helix-website--adobe.aem.live/fragments/homepage-quiz.plain.html'] = new Response(`<div class="quiz-fragment">
+  <p>Take the quiz</p>
+</div>`, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const response = new Response(`<main>
+  <p><a href="/fragments/homepage-quiz">https://main--demo--scdemos.aem.live/fragments/homepage-quiz</a></p>
+</main>`, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, `<main>
+  <div class="quiz-fragment">
+    <p>Take the quiz</p>
+  </div>
+</main>`);
+  });
+
+  it('should inline fragment markers by replacing a simple div wrapper', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    mockResponses['https://main--helix-website--adobe.aem.live/fragments/homepage-quiz.plain.html'] = new Response('<div class="quiz-fragment">Take the quiz</div>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const response = new Response(`<main>
+  <div>
+    <a href="/fragments/homepage-quiz">https://main--demo--scdemos.aem.live/fragments/homepage-quiz</a>
+  </div>
+</main>`, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, `<main>
+  <div class="quiz-fragment">Take the quiz</div>
+</main>`);
+  });
+
+  it('should inline fragment markers with anchor-only fallback when the parent has other content', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    mockResponses['https://main--helix-website--adobe.aem.live/fragments/homepage-quiz.plain.html'] = new Response('<span class="quiz-fragment">Take the quiz</span>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const response = new Response('<p>Before <a href="/fragments/homepage-quiz">quiz</a> after</p>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, '<p>Before <span class="quiz-fragment">Take the quiz</span> after</p>');
+  });
+
+  it('should keep surrounding section content when only the marker paragraph should be replaced', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    mockResponses['https://main--helix-website--adobe.aem.live/fragments/homepage-quiz.plain.html'] = new Response(`<div class="quiz-fragment">
+  <p>Take the quiz</p>
+</div>`, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const response = new Response(`<div>
+  <h2>Take A Quiz</h2>
+  <p><a href="/fragments/homepage-quiz">https://main--demo--scdemos.aem.live/fragments/homepage-quiz</a></p>
+  <div class="section-metadata"><div><div>style</div><div>divider</div></div></div>
+</div>`, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, `<div>
+  <h2>Take A Quiz</h2>
+  <div class="quiz-fragment">
+    <p>Take the quiz</p>
+  </div>
+  <div class="section-metadata"><div><div>style</div><div>divider</div></div></div>
+</div>`);
+  });
+
+  it('should not inline nav or footer when only fragment paths are configured', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        inlineNav: false,
+        inlineFooter: false,
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    mockResponses['https://main--helix-website--adobe.aem.live/nav/nav.plain.html'] = new Response('<nav>Should not inline</nav>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const initialBody = `<head>
+  <meta name="nav" content="/nav/nav">
+</head>
+<body>
+  <header></header>
+</body>`;
+    const response = new Response(initialBody, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, initialBody);
+  });
+
+  it('should support multiple inline path prefixes and normalize .plain.html with query strings', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/', '/blocks/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    mockResponses['https://main--helix-website--adobe.aem.live/blocks/promo.plain.html?variant=blue'] = new Response('<div class="promo-fragment">Promo</div>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const response = new Response('<p><a href="/blocks/promo?variant=blue#top">promo</a></p>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, '<div class="promo-fragment">Promo</div>');
+  });
+
+  it('should skip fragment work when inlineFragments has no path prefixes and markup has no #inline', async () => {
+    const localFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = async (...args) => {
+      fetchCalls += 1;
+      return localFetch.call(globalThis, ...args);
+    };
+
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: [] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    const initialBody = '<p><a href="/fragments/homepage-quiz">quiz</a></p>';
+    const response = new Response(initialBody, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(fetchCalls, 0);
+    assert.strictEqual(body, initialBody);
+  });
+
+  it('should inline href ending with #inline when inlineFragments has no path prefixes', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: {},
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    mockResponses['https://main--helix-website--adobe.aem.live/fragments/homepage-quiz.plain.html'] = new Response('<div class="quiz">Q</div>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const response = new Response('<p><a href="/fragments/homepage-quiz#inline">x</a></p>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, '<div class="quiz">Q</div>');
+  });
+
+  it('should skip anchor scanning entirely when configured paths do not appear in the markup', async () => {
+    const localFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = async (...args) => {
+      fetchCalls += 1;
+      return localFetch.call(globalThis, ...args);
+    };
+
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    const initialBody = '<p><a href="/not-fragments/homepage-quiz">quiz</a></p>';
+    const response = new Response(initialBody, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(fetchCalls, 0);
+    assert.strictEqual(body, initialBody);
+  });
+
+  it('should not treat path prefixes as substring matches (e.g. /fragments/ vs /fragmentsfoo/)', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    const initialBody = '<p><a href="/fragmentsfoo/home">not a real fragment path</a></p>';
+    const response = new Response(initialBody, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, initialBody);
+  });
+
+  it('should ignore protocol-relative and absolute hrefs for fragment detection', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    const initialBody = '<p><a href="//other.example/fragments/x">a</a> <a href="https://main--helix-website--adobe.aem.live/fragments/y">b</a></p>';
+    const response = new Response(initialBody, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, initialBody);
+  });
+
+  it('should ignore absolute fragment urls and plain-text urls in the body', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    const initialBody = `<p><a href="https://main--demo--scdemos.aem.live/fragments/homepage-quiz">https://main--demo--scdemos.aem.live/fragments/homepage-quiz</a></p>
+<p>https://main--demo--scdemos.aem.live/fragments/whats-next</p>`;
+    const response = new Response(initialBody, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, initialBody);
+  });
+
+  it('should dedupe identical fragment subrequests within one response', async () => {
+    const localFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = async (...args) => {
+      fetchCalls += 1;
+      return localFetch.call(globalThis, ...args);
+    };
+
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    mockResponses['https://main--helix-website--adobe.aem.live/fragments/homepage-quiz.plain.html'] = new Response('<div class="quiz-fragment">Take the quiz</div>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const response = new Response(`<main>
+  <p><a href="/fragments/homepage-quiz">one</a></p>
+  <p><a href="/fragments/homepage-quiz">two</a></p>
+</main>`, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(fetchCalls, 1);
+    assert.strictEqual(body, `<main>
+  <div class="quiz-fragment">Take the quiz</div>
+  <div class="quiz-fragment">Take the quiz</div>
+</main>`);
+  });
+
+  it('should leave fragment markers unchanged when the fragment subrequest returns non-200', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    const initialBody = '<p><a href="/fragments/missing">quiz</a></p>';
+    mockResponses['https://main--helix-website--adobe.aem.live/fragments/missing.plain.html'] = new Response('Not Found', { status: 404 });
+
+    const response = new Response(initialBody, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, initialBody);
+  });
+
+  it('should leave fragment markers unchanged when the fragment response is not html', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    const initialBody = '<p><a href="/fragments/homepage-quiz">quiz</a></p>';
+    mockResponses['https://main--helix-website--adobe.aem.live/fragments/homepage-quiz.plain.html'] = new Response('plain text', {
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+    });
+
+    const response = new Response(initialBody, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, initialBody);
+  });
+
+  it('should merge cache keys from fragment subrequests', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    mockResponses['https://main--helix-website--adobe.aem.live/fragments/homepage-quiz.plain.html'] = new Response('<div class="quiz-fragment">Take the quiz</div>', {
+      status: 200,
+      headers: {
+        'content-type': 'text/html',
+        'surrogate-key': 'frag1 frag2',
+        'edge-cache-tag': 'ak1,ak2',
+        'x-cache-tag': 'cfx1,cfx2',
+      },
+    });
+
+    const response = new Response('<p><a href="/fragments/homepage-quiz">quiz</a></p>', {
+      status: 200,
+      headers: {
+        'content-type': 'text/html',
+        'surrogate-key': 'root1',
+        'edge-cache-tag': 'root-ak',
+        'cache-tag': 'root-cf',
+      },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    assert.strictEqual(result.headers.get('surrogate-key'), 'root1 frag1 frag2');
+    assert.strictEqual(result.headers.get('edge-cache-tag'), 'root-ak,ak1,ak2');
+    assert.strictEqual(result.headers.get('cache-tag'), 'root-cf,cfx1,cfx2');
+    assert.strictEqual(result.headers.get('x-cache-tag'), 'root-cf,cfx1,cfx2');
+  });
+
   it('should inline nav', async () => {
     const ctx = TEST_CONTEXT({
       config: {
@@ -234,12 +658,50 @@ describe('inlines tests', () => {
     assert.strictEqual(result.headers.get('cache-tag'), 'baz,baz2,ec1,ec2');
   });
 
-  it('should send push invalidation headers for nav/footer subrequests', async () => {
+  it('should send push invalidation headers for fragment subrequests', async () => {
     const localFetch = globalThis.fetch;
-    after(() => {
-      globalThis.fetch = localFetch;
+    let fragmentFetchCount = 0;
+    globalThis.fetch = async (...args) => {
+      const [url, init] = args;
+      if (String(url).includes('/fragments/push-test.plain.html')) {
+        fragmentFetchCount += 1;
+        assert.strictEqual(init.headers['accept-encoding'], 'identity');
+        assert.strictEqual(init.headers['x-push-invalidation'], 'enabled');
+        assert.strictEqual(init.headers['x-byo-cdn-type'], 'akamai');
+      }
+      return localFetch.call(globalThis, ...args);
+    };
+
+    const ctx = TEST_CONTEXT({
+      info: {
+        headers: {
+          'x-byo-cdn-type': 'akamai',
+          'x-push-invalidation': 'enabled',
+        },
+      },
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
     });
 
+    mockResponses['https://main--helix-website--adobe.aem.live/fragments/push-test.plain.html'] = new Response('<div>ok</div>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const response = new Response('<p><a href="/fragments/push-test">x</a></p>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    await result.text();
+    assert.strictEqual(fragmentFetchCount, 1);
+  });
+
+  it('should send push invalidation headers for nav/footer subrequests', async () => {
+    const localFetch = globalThis.fetch;
     let fetchCalls = 0;
     globalThis.fetch = async (...args) => {
       const [_, { headers }] = args;
@@ -341,5 +803,107 @@ describe('inlines tests', () => {
     // Both headers should contain the union of x-cache-tag values from subresources
     assert.strictEqual(result.headers.get('x-cache-tag'), 'xn1,xn2,xf1,xf2');
     assert.strictEqual(result.headers.get('cache-tag'), 'xn1,xn2,xf1,xf2');
+  });
+
+  it('should inline a fragment via #inline hash even when its path is not in configured paths', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    mockResponses['https://main--helix-website--adobe.aem.live/promo/winter.plain.html'] = new Response('<div class="promo">Winter Sale</div>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const response = new Response('<p><a href="/promo/winter#inline">winter promo</a></p>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, '<div class="promo">Winter Sale</div>');
+  });
+
+  it('should inline a fragment via #inline hash even when its path does not match any configured path', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/pathA', '/fragments/pathB'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    mockResponses['https://main--helix-website--adobe.aem.live/any/path.plain.html'] = new Response('<div class="anything">Content</div>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const response = new Response('<p><a href="/any/path#inline">content</a></p>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, '<div class="anything">Content</div>');
+  });
+
+  it('should inline both configured fragments and nav in one HTML document', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineNav: true,
+        inlineFragments: { paths: ['/fragments/'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    mockResponses['https://main--helix-website--adobe.aem.live/nav/nav.plain.html'] = new Response('<nav>Inlined Nav</nav>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+    mockResponses['https://main--helix-website--adobe.aem.live/fragments/banner.plain.html'] = new Response('<div class="banner">Banner</div>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const initial = `<head>
+  <meta name="nav" content="/nav/nav">
+</head>
+<body>
+  <header></header>
+  <main><p><a href="/fragments/banner">fragment marker</a></p></main>
+</body>`;
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), new Response(initial, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    }));
+    const body = await result.text();
+    assert.match(body, /<nav>Inlined Nav<\/nav>/);
+    assert.match(body, /<div class="banner">Banner<\/div>/);
+    assert.ok(!body.includes('<header></header>'));
+    assert.ok(!body.includes('fragment marker'));
+  });
+
+  it('should not inline a fragment with #inline-section (not exact #inline hash)', async () => {
+    const ctx = TEST_CONTEXT({
+      config: {
+        inlineFragments: { paths: ['/fragments/pathA', '/fragments/pathB'] },
+        origin: 'main--helix-website--adobe.aem.live',
+      },
+    });
+
+    const initialBody = '<p><a href="/path/page#inline-section">link</a></p>';
+    const response = new Response(initialBody, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await inlineResources(ctx, new URL('https://main--helix-website--adobe.aem.live'), response);
+    const body = await result.text();
+    assert.strictEqual(body, initialBody);
   });
 });

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -11,7 +11,11 @@
  */
 
 import assert from 'node:assert';
-import { getEffectiveDomain, globToRegExp, isCustomDomain } from '../src/util.js';
+import {
+  getEffectiveDomain,
+  globToRegExp,
+  isCustomDomain,
+} from '../src/util.js';
 
 describe('util tests', () => {
   describe('globToRegExp', () => {


### PR DESCRIPTION
Add support for inlining fragments into page markup, complementing the existing nav/footer inlining.

Fragments are identified by:
- Configured path prefixes in `inlineFragments.paths` (e.g. `/fragments/something/`)
- Explicit `#inline` hash suffix on anchor hrefs (author managed for specific fragments)

Fragment inlining is purely additive — existing nav/footer behavior is unchanged. 
Fragment sub-requests are deduped and fetched in parallel, with cache keys (surrogate-key, edge-cache-tag, cache-tag, x-cache-tag) merged into the parent response for proper invalidation.

Also fixes a latent bug where `res.json()` on the config service response fails on Fastly Compute because the CDN returns gzip-encoded bodies and Fastly's fetch API does not auto-decompress. The config response is now explicitly decompressed before parsing.