### PR TITLE
test: use live id.aem.domains for DNS CNAME test

### DIFF
--- a/test/dns.live.test.js
+++ b/test/dns.live.test.js
@@ -26,8 +26,8 @@ describe('dns live tests (Google DoH)', function suite() {
     assert.strictEqual(cname, null);
   });
 
-  it.skip('returns CNAME for www.wagenerbeer.com', async () => {
-    const cname = await resolveCustomDomain('www.wagenerbeer.com'); // uses DoH
+  it('returns CNAME for id.aem.domains', async () => {
+    const cname = await resolveCustomDomain('id.aem.domains'); // uses DoH
     assert.strictEqual(cname, 'main--id--davidnuescheler.domains.aem.network');
   });
 });


### PR DESCRIPTION
## What

The live DNS test (`test/dns.live.test.js`) asserted that `resolveCustomDomain` returns a CNAME for `www.wagenerbeer.com`. That domain has since lapsed — both the apex and `www` now return **NXDOMAIN** from Google DoH — so `resolveCustomDomain` correctly returns `null` and the assertion failed:

```
+ null
- 'main--id--davidnuescheler.domains.aem.network'
```

## Change

- Swap the fixture to `id.aem.domains`, a domain we control (Porkbun), CNAME'd to the same AEM network origin: `main--id--davidnuescheler.domains.aem.network`.
- Re-enable the previously `.skip`'d assertion so it runs in CI again.

Expected value is unchanged since both names point at the same AEM target.

## Verification

Runs through the real code path (races Cloudflare `1.1.1.1` + `dns.google`, parses the binary `application/dns-message` response, checks the `*--*--*.domains.aem.network` pattern):

```
dns live tests (Google DoH)
  ✔ returns null for example.com (not an AEM custom domain)
  ✔ returns CNAME for id.aem.domains

2 passing
```

> [!NOTE]
> This remains a live test tied to a DNS record we control, so the `id.aem.domains` CNAME at Porkbun must stay in place. If we want to drop the external dependency entirely, a follow-up could mock the DoH byte response instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)